### PR TITLE
Prefer configRevision in the cache-actuality fallback chain

### DIFF
--- a/components-registry/pom.xml
+++ b/components-registry/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>org.octopusden.octopus.infrastructure</groupId>
             <artifactId>components-registry-service-client</artifactId>
-            <version>3.0.1</version>
+            <version>3.0.11</version>
         </dependency>
         <dependency>
             <groupId>io.github.openfeign</groupId>

--- a/components-registry/src/main/kotlin/org/octopusden/octopus/jira/config/ComponentRegistryServiceImpl.kt
+++ b/components-registry/src/main/kotlin/org/octopusden/octopus/jira/config/ComponentRegistryServiceImpl.kt
@@ -303,7 +303,9 @@ class ComponentRegistryServiceImpl @Inject constructor(
 
     override fun checkCacheActualityAndClean(forceClean: Boolean): UpdateCacheResult {
         val serviceStatus = client.getServiceStatus()
-        val remoteStatus = serviceStatus.versionControlRevision ?: serviceStatus.cacheUpdatedAt
+        val remoteStatus = serviceStatus.configRevision
+            ?: serviceStatus.versionControlRevision
+            ?: serviceStatus.cacheUpdatedAt
 
         val previousFixedRemoteStatus = this.fixedRemoteStatus
         val needClean = forceClean || previousFixedRemoteStatus != remoteStatus


### PR DESCRIPTION
## Prefer configRevision in the cache-actuality fallback chain

`checkCacheActualityAndClean` compared `versionControlRevision ?: cacheUpdatedAt`.
Neither token moves when config is written through the portal/DB path:
`versionControlRevision` stays frozen (or null with VCS disabled) and
`cacheUpdatedAt` is fixed at service boot.